### PR TITLE
Expose worker messages to parent window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15850,8 +15850,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.2",
@@ -16250,8 +16249,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -16285,15 +16283,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -21555,8 +21551,7 @@
     "material-ui-color": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/material-ui-color/-/material-ui-color-1.2.0.tgz",
-      "integrity": "sha512-bD2Rww+hakJxD2/19uxc280Vh292DnRStLke2LDFavVtGd5fzOz09zIrHO3ZHlMkJFsvwx6IwiB4/932ftv0sQ==",
-      "requires": {}
+      "integrity": "sha512-bD2Rww+hakJxD2/19uxc280Vh292DnRStLke2LDFavVtGd5fzOz09zIrHO3ZHlMkJFsvwx6IwiB4/932ftv0sQ=="
     },
     "material-ui-popup-state": {
       "version": "1.8.4",
@@ -21846,8 +21841,7 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
-      "requires": {}
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -23065,8 +23059,7 @@
     "react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
-      "requires": {}
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-transition-group": {
       "version": "4.4.2",
@@ -24977,8 +24970,7 @@
     "use-debounce": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-0.0.7.tgz",
-      "integrity": "sha512-707DtxeP/tcUOFf0rU9yffgOrgfyBOSAnKdUDnyWSDAVkcd+P7tXxfJqvOEqffva9066EFgTKp/g8A6XrC+xSw==",
-      "requires": {}
+      "integrity": "sha512-707DtxeP/tcUOFf0rU9yffgOrgfyBOSAnKdUDnyWSDAVkcd+P7tXxfJqvOEqffva9066EFgTKp/g8A6XrC+xSw=="
     },
     "util": {
       "version": "0.11.1",

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,8 @@ const APP = observer(() => {
   useEffect(() => {
     webworkerStore.addWorkerEventListener(d => {
       const { type, data } = d;
+      // Replay worker messages into parent window for iframe --> page communication.
+      window.parent.postMessage(JSON.stringify({ type, data }), "*");
       switch (type) {
         case 'update loading screen':
           uiStore.setLoadingScreenProcessType(data.processType);

--- a/src/store/filedata/index.js
+++ b/src/store/filedata/index.js
@@ -26,6 +26,7 @@ export default class State {
     this.terminology = _clone(defaultTerminology);
     this.templates = {};
     this.styles = {};
+    this.previousJsonData = {};
   }
 
   get parameters() {
@@ -56,6 +57,10 @@ export default class State {
 
   setJsonFile(jsonFile) {
     this.jsonFile = jsonFile;
+  }
+
+  setPreviousJsonData(jsonData) {
+    this.previousJsonData = jsonData;
   }
 
   setMapData(mapData) {
@@ -129,5 +134,9 @@ export default class State {
 
   getStyles() {
     return this.jsonData.config ? this.jsonData.config.styles : undefined;
+  }
+
+  getPreviousJsonData() {
+    return this.previousJsonData;
   }
 }

--- a/src/workers/worker.js
+++ b/src/workers/worker.js
@@ -173,7 +173,7 @@ function _parseJsonFile(jsonFileOrUrl) {
       const reader = new FileReader();
       reader.readAsText(jsonFileOrUrl, 'UTF-8');
       reader.onload = event => {
-        _parseJsonData(event.target.result);
+        _parseJson(event.target.result);
       };
       reader.onerror = () => {
         const fileError = getFileReaderError(reader.error, fileTypeKeys.VOSVIEWER_JSON_FILE);
@@ -182,6 +182,30 @@ function _parseJsonFile(jsonFileOrUrl) {
           data: { fileError },
         });
       };
+    } else if (jsonFileOrUrl instanceof Object && jsonFileOrUrl.url) {
+      fetch(jsonFileOrUrl.url, { credentials: "include", method: jsonFileOrUrl.method, body: jsonFileOrUrl.body })
+        .then(response => {
+          if (!response.ok) {
+            if (response.status === 404) {
+              throw new Error('Not Found');
+            } else {
+              throw new Error(response.statusText);
+            }
+          }
+          return response.text();
+        })
+        .then(text => {
+          _parseJson(text);
+        })
+        .catch(error => {
+          const fileError = getFileReaderError(error, fileTypeKeys.VOSVIEWER_JSON_FILE);
+          self.postMessage({
+            type: 'end parse vosviewer-json file',
+            data: { fileError },
+          });
+        });
+    } else if (jsonFileOrUrl instanceof Object && !jsonFileOrUrl.url) {
+      _parseJson(jsonFileOrUrl);
     } else {
       fetch(jsonFileOrUrl, { credentials: "include" })
         .then(response => {
@@ -195,7 +219,7 @@ function _parseJsonFile(jsonFileOrUrl) {
           return response.text();
         })
         .then(text => {
-          _parseJsonData(text);
+          _parseJson(text);
         })
         .catch(error => {
           const fileError = getFileReaderError(error, fileTypeKeys.VOSVIEWER_JSON_FILE);
@@ -208,17 +232,21 @@ function _parseJsonFile(jsonFileOrUrl) {
   }
 }
 
-function _parseJsonData(text) {
+function _parseJson(jsonObjectOrText) {
   let fileError;
   let jsonData = {};
   let mapData = [];
   let networkData = [];
 
   let data;
-  try {
-    data = JSON.parse(text);
-  } catch (error) {
-    data = undefined;
+  if (jsonObjectOrText instanceof Object) {
+    data = jsonObjectOrText;
+  } else {
+    try {
+      data = JSON.parse(jsonObjectOrText);
+    } catch (error) {
+      data = undefined;
+    }
   }
   if (data && data.network && (data.network.items || data.network.links)) {
     jsonData = _cloneDeep(data) || {};
@@ -272,7 +300,7 @@ function _parseJsonData(text) {
       uniqueItemIds.sort();
       mapData = uniqueItemIds.map(d => ({ id: d }));
     }
-  } else if (text === "") {
+  } else if (jsonObjectOrText === "") {
     fileError = getFileError(errorKeys.FILE_EMPTY, fileTypeKeys.VOSVIEWER_JSON_FILE);
   } else {
     fileError = getFileError(errorKeys.INVALID_JSON_DATA_FORMAT, fileTypeKeys.VOSVIEWER_JSON_FILE);


### PR DESCRIPTION
When integrating the VOSviewer with an `iframe` it's useful for the parent to know of any errors that happened in the VOSApp. In this PR we replay the worker messages back to the parent. The parent can then process the message and act accordingly. 

Example usage: https://codesandbox.io/s/zen-hooks-8k0zf?file=/src/index.js
<img width="1374" alt="Screenshot 2021-12-28 at 5 21 20 PM" src="https://user-images.githubusercontent.com/39321865/147586089-0ad2a693-b736-4233-ae6a-dccf27b493b4.png">

