### PR TITLE
Fix cluster legend labels issue

### DIFF
--- a/src/components/ui/ClusterColorLegend/index.js
+++ b/src/components/ui/ClusterColorLegend/index.js
@@ -52,7 +52,7 @@ const ClusterColorLegend = observer(({ showTopClustersOnly, canvasWidth, legendW
 
     ctx.clearRect(0, 0, canvasWidth * visualizationStore.pixelRatio, canvasHeight * visualizationStore.pixelRatio);
 
-    ctx.font = `0.75rem ${font}`;
+    ctx.font = `${12 * visualizationStore.pixelRatio}px ${font}`;
     ctx.textBaseline = 'middle';
     ctx.lineWidth = lineWidth * visualizationStore.pixelRatio;
 


### PR DESCRIPTION
Fixes #18 by making the font size of legend labels dependent on the device pixel ratio.