### PR TITLE
Share functionality and TinyURL usage

### DIFF
--- a/src/components/ui/Share/index.js
+++ b/src/components/ui/Share/index.js
@@ -29,7 +29,8 @@ const Share = observer(() => {
   const uiStore = useContext(UiStoreContext);
   const visualizationStore = useContext(VisualizationStoreContext);
   const [isOpen, setIsOpen] = useState(false);
-  const [useShortLink, setUseShortLink] = useState(true);
+  // Set shortlink as disabled per default (opt-in mechanism)
+  const [useShortLink, setUseShortLink] = useState(false);
   const [useCustomSettings, setUseCustomSettings] = useState(false);
   const [link, setLink] = useState('');
   const [embedCode, setEmbedCode] = useState('');

--- a/src/pages/Dimensions/index.js
+++ b/src/pages/Dimensions/index.js
@@ -120,7 +120,7 @@ const Dimensions = observer(({ queryString = {}, fullscreenHandle }) => {
             <>
               <Open />
               <Save />
-              <Share />
+              {configStore.uiConfig.share_icon && <Share />}
               <Screenshot />
             </>
           )}

--- a/src/pages/VOSviewer/index.js
+++ b/src/pages/VOSviewer/index.js
@@ -108,7 +108,7 @@ const VOSviewer = observer(({ queryString = {}, fullscreenHandle }) => {
         <div className={`${s.actionIcons(configStore.urlPreviewPanelWidth)} ${configStore.urlPreviewPanel ? s.previewIsOpen : ''}`}>
           <Open />
           <Save />
-          <Share />
+          {configStore.uiConfig.share_icon && <Share />}
           <Screenshot />
           <DarkLightTheme />
           <Info />

--- a/src/pages/ZetaAlpha/index.js
+++ b/src/pages/ZetaAlpha/index.js
@@ -118,7 +118,7 @@ const ZetaAlpha = observer(({ queryString = {}, fullscreenHandle }) => {
         <div className={`${s.actionIcons(configStore.urlPreviewPanelWidth)} ${configStore.urlPreviewPanel ? s.previewIsOpen : ''}`}>
           <Open />
           <Save />
-          <Share />
+          {configStore.uiConfig.share_icon && <Share />}
           <Screenshot />
           <DarkLightTheme />
           <Fullscreen enter={fullscreenHandle.enter} exit={fullscreenHandle.exit} active={fullscreenHandle.active} />


### PR DESCRIPTION
Hi @neesjanvaneck,

I'm Andi from the Dimensions team. We've been working with the Share functionality and have a couple of suggestions we believe could enhance it:

1. Conditional Rendering for the <Share /> Component: We've noticed that even when sharing is disabled in the configuration, the <Share /> component still renders, triggering its [useEffect](https://github.com/neesjanvaneck/VOSviewer-Online/pull/70/files#diff-386996436f5787c8ca652918572dc8d648a64e942864234fbae1bfa936b300fcR39) hook and making calls to services like tinyurl.com. We propose conditionally rendering the component so it doesn't mount at all if sharing is turned off. This would prevent unnecessary network requests.
2. Opt-In Approach for Short URL Services: Currently, the TinyURL service is used by default. For greater transparency and to align with data privacy considerations like GDPR and FedRAMP compliance, we suggest making the use of short URL services an opt-in feature rather than opt-out.
Please let me know if you have any questions or would like to discuss these points further. I'm happy to provide more details or hop on a call.

Best regards,

Andi

### Updates to the `Share` component:

* [`src/components/ui/Share/index.js`](diffhunk://#diff-386996436f5787c8ca652918572dc8d648a64e942864234fbae1bfa936b300fcL32-R33): Changed the default state of `useShortLink` to `false`, making short links opt-in instead of enabled by default.

### Conditional rendering of the `Share` icon:

* [`src/pages/Dimensions/index.js`](diffhunk://#diff-8283ebea05b1abcaf55839bbda3453f33ef8335a40e4f36434594cf0d441c260L123-R123): Added conditional rendering for the `Share` icon based on the `uiConfig.share_icon` flag in `configStore`.
* [`src/pages/VOSviewer/index.js`](diffhunk://#diff-088d2c2e3055ad619f5f17f3cd26fcca87467de208a62706ca66c0174c3e7841L111-R111): Updated the `Share` icon to render only if the `uiConfig.share_icon` flag is enabled.
* [`src/pages/ZetaAlpha/index.js`](diffhunk://#diff-c53fce2fd8ddf51d2d0792bde1cf1de4fa8674500486f590b5cb2dfa51d6372cL121-R121): Modified the rendering of the `Share` icon to be conditional on the `uiConfig.share_icon` flag in `configStore`.